### PR TITLE
Update Abstraction.sol

### DIFF
--- a/contracts/Abstraction.sol
+++ b/contracts/Abstraction.sol
@@ -31,6 +31,7 @@ contract Abstraction is ERC721URIStorage {
     event MintNewTokenEvent(address indexed minter, uint256 tokenId);
     event BuyTokenEvent(address indexed buyer, uint256 tokenId);
     event GiftTokenEvent(address indexed from, address indexed to, uint256 tokenId);
+    event BuyTokenAsGiftEvent(address indexed from, address indexed to, uint256 tokenId);
 
     constructor() ERC721("Abstraction Collectible", "ABS") {
         owner = payable(msg.sender);
@@ -126,8 +127,8 @@ contract Abstraction is ERC721URIStorage {
         _transfer(address(this), _beneficiary, _tokenId);        
         tokenSold.increment();    
         (bool sentSalesPriceToSeller, ) = _seller.call{value: msg.value}("");
-        require(sentSalesPriceToSeller, "failed to send celo to seller");
-        emit BuyTokenEvent(msg.sender, _tokenId);
+        require(sentSalesPriceToSeller, "failed to send celo to seller");        
+        emit BuyTokenAsGiftEvent(msg.sender, _beneficiary, _tokenId);
     }
 
     // sell token 

--- a/contracts/Abstraction.sol
+++ b/contracts/Abstraction.sol
@@ -77,8 +77,7 @@ contract Abstraction is ERC721URIStorage {
                 allMyTokens[counter] = id;
                 counter++;
             }
-        }
-        
+        }        
         return allMyTokens;
     }
 
@@ -95,7 +94,6 @@ contract Abstraction is ERC721URIStorage {
                 counter++;
             }
         }
-
         return allItems;
     }
 
@@ -113,12 +111,27 @@ contract Abstraction is ERC721URIStorage {
         tokenSold.increment();    
         _seller.transfer(msg.value);
         emit BuyTokenEvent(msg.sender, _tokenId);
+    } 
+
+    // purchase token as gift
+    function purchaseTokenAsGift(uint256 _tokenId, address _beneficiary) public payable {
+        uint256 tokenPrice = tokenItems[_tokenId].tokenPrice;
+        require(tokenPrice <= msg.value, "insufficient funds!");
+        address payable _seller = payable(tokenItems[_tokenId].seller);
+
+        tokenItems[_tokenId].seller = payable(address(0));
+        tokenItems[_tokenId].owner = payable(_beneficiary);
+        tokenItems[_tokenId].sold = true;
+
+        _transfer(address(this), _beneficiary, _tokenId);        
+        tokenSold.increment();    
+        (bool sentSalesPriceToSeller, ) = _seller.call{value: msg.value}("");
+        require(sentSalesPriceToSeller, "failed to send celo to seller");
+        emit BuyTokenEvent(msg.sender, _tokenId);
     }
 
     // sell token 
-    function sellToken(uint256 _tokenId, uint256 _newPrice) public {
-        require(ownerOf(_tokenId) == msg.sender, "You are not the owner!");
-        require(_newPrice > 0, "Price too low!");
+    function sellToken(uint256 _tokenId, uint256 _newPrice) public canSellToken(_tokenId, _newPrice){       
         tokenItems[_tokenId] = TokenItem(
             _tokenId,
             _newPrice, 
@@ -142,13 +155,21 @@ contract Abstraction is ERC721URIStorage {
     }
 
     // gift token to another user
-    function giftToken(uint256 _tokenId, address _beneficiary) public payable {
-        require(ownerOf(_tokenId) == msg.sender, "You are not the owner!"); 
-        require(_beneficiary != address(0));
-        require(msg.sender != address(0));
-
+    function giftToken(uint256 _tokenId, address _beneficiary) public payable canGiftToken(_tokenId, _beneficiary) {
         transferFrom(msg.sender, _beneficiary, _tokenId);
         emit GiftTokenEvent(msg.sender, _beneficiary, _tokenId);
+    }
+
+    modifier canSellToken(uint256 _tokenId, uint256 _newPrice) {
+        require(ownerOf(_tokenId) == msg.sender, "You are not the owner!");
+        require(_newPrice > 0, "Price too low!");
+        _;
+    }
+
+    modifier canGiftToken(uint256 _tokenId,  address _beneficiary) {
+        require(ownerOf(_tokenId) == msg.sender, "You are not the owner!"); 
+        require(_beneficiary != address(0));
+        _;
     }
 
 }


### PR DESCRIPTION
- Added a function `purchaseTokenAsGift` function that allows an account to buy token for another account as a gift. I saw the `giftToken` function and thought of writing a function to handle gift purchases as well.

- Created 2 modifiers: `canGiftToken` and `canSellToken` to handle the require statements that checks if all the requirements are met before the tokens can be gifted or sold.

- changed how the celo is transferred to use `call` instead of transfer

- added BuyTokenAsGiftEvent to purchaseTokenAsGift function